### PR TITLE
Editor: Truncate Filename in Tabs

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -739,7 +739,7 @@ impl Item for Editor {
         h_flex()
             .gap_2()
             .child(
-                Label::new(self.title(cx).to_string())
+                Label::new(util::truncate_and_trailoff(&self.title(cx), MAX_TAB_TITLE_LEN))
                     .color(label_color)
                     .when(params.preview, |this| this.italic())
                     .when(was_deleted, |this| this.strikethrough()),


### PR DESCRIPTION
Closes #3 

This PR adds truncation for overly long filenames displayed in tabs. Previously, long filenames were shown in full, which made the tabs look cluttered and visually unappealing. With this change, filenames are shortened for a cleaner, more consistent tab layout.

Before:
<img width="1552" height="907" alt="truncate_filenames_tabs_before" src="https://github.com/user-attachments/assets/383d76c2-0d64-41f2-8c47-43ffb47b5475" />

After:
<img width="1552" height="907" alt="truncate_filenames_tabs_after" src="https://github.com/user-attachments/assets/6fdfda99-14bc-46ca-b565-684f5db34ba1" />

Release Notes:

- Editor: truncate overly long filenames in tabs
